### PR TITLE
Refactor API key response mapping to use TypeScript interfaces

### DIFF
--- a/src/routes/apiKeys.ts
+++ b/src/routes/apiKeys.ts
@@ -187,13 +187,32 @@ export default async function apiKeysRoute(fastify: FastifyInstance) {
       }
 
       // Return masked API keys with metadata
-      const apiKeys = user.apiKeys.map((key) => ({
-        id: key.id,
-        key: maskApiKey(key.key), // Use our utility function to mask the key
-        createdAt: key.createdAt.toISOString(),
-        totalUsed: key.totalUsed,
-        status: key.status,
-      }));
+      interface ApiKeyResponse {
+        id: string;
+        key: string;
+        createdAt: string;
+        totalUsed?: number;
+        status: string;
+      }
+
+      const apiKeys: ApiKeyResponse[] = user.apiKeys.map((key: {
+        id: string;
+        key: string;
+        createdAt: Date;
+        totalUsed?: number;
+        status: string;
+      }): ApiKeyResponse => {
+        const apiKeyObj: ApiKeyResponse = {
+          id: key.id,
+          key: maskApiKey(key.key),
+          createdAt: key.createdAt.toISOString(),
+          status: key.status,
+        };
+        if (key.totalUsed !== undefined) {
+          apiKeyObj.totalUsed = key.totalUsed;
+        }
+        return apiKeyObj;
+      });
 
       return reply.status(HttpStatusCode.OK).send({
         success: true,


### PR DESCRIPTION
This PR fixes the type issue by adding an interface to the API key response

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized GET /api-keys response for improved consistency and safety: API keys are masked in listings, createdAt is consistently formatted, and total usage is included when available. Status values are unchanged. These adjustments improve reliability without altering endpoint paths or request parameters, and are backward-compatible for typical clients consuming this endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->