### PR TITLE
feat: implement notifications route for fetching

### DIFF
--- a/src/routes/notifications.ts
+++ b/src/routes/notifications.ts
@@ -1,16 +1,37 @@
 import type { FastifyInstance, FastifyPluginOptions } from 'fastify';
 
+// In-memory store for notifications (replace with DB in production)
+const notifications: Array<{
+  id: string;
+  user: string;
+  message: string;
+  createdAt: Date;
+}> = [];
+
+
 async function notificationsRoutes(fastify: FastifyInstance, options: FastifyPluginOptions) {
   // GET /notifications - fetch all notifications
   fastify.get('/notifications', async (request, reply) => {
-    // TODO: Replace with actual notification fetching logic
-    return { message: 'List of notifications' };
+    // Return all notifications
+    return notifications;
   });
 
   // POST /notifications - create a new notification
   fastify.post('/notifications', async (request, reply) => {
-    // TODO: Replace with actual notification creation logic
-    return { message: 'Notification created' };
+    const { user, message } = request.body as { user?: string; message?: string };
+    if (!user || !message) {
+      reply.status(400);
+      return { error: 'User and message are required.' };
+    }
+    const newNotification = {
+      id: Math.random().toString(36).substr(2, 9),
+      user,
+      message,
+      createdAt: new Date(),
+    };
+    notifications.push(newNotification);
+    reply.status(201);
+    return newNotification;
   });
 }
 


### PR DESCRIPTION
The notification route now uses an in-memory array to store notifications. Users can fetch all notifications with GET `/notifications` and create a new notification with POST `/notifications` by providing `user` and `message` in the request body.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled a functional notifications API: GET /notifications returns the current list; POST /notifications creates a notification when provided user and message, returning the created item (id, user, message, createdAt) with 201 status.

* **Bug Fixes**
  * Replaced placeholder responses with real data.
  * Added input validation for POST /notifications; missing user or message now returns a 400 status with an error message for clearer, consistent error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->